### PR TITLE
[Feat] 공통 엔티티에 감사(Audit) 및 엔티티 상태 관리 기능 추가

### DIFF
--- a/src/main/java/com/PickOne/common/config/AuditConfig.java
+++ b/src/main/java/com/PickOne/common/config/AuditConfig.java
@@ -1,0 +1,22 @@
+package com.PickOne.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditConfig {
+    // 현재 사용자 정보를 제공하는 Bean
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> {
+            // 실제 구현에서는 SecurityContextHolder 등을 통해
+            // 현재 인증된 사용자 정보를 반환
+            return Optional.of("SYSTEM"); // 임시 하드코딩
+        };
+    }
+}

--- a/src/main/java/com/PickOne/common/entity/BaseEntity.java
+++ b/src/main/java/com/PickOne/common/entity/BaseEntity.java
@@ -1,0 +1,74 @@
+package com.PickOne.common.entity;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    // 생성 시간 (수정 불가)
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    // 최종 수정 시간
+    private LocalDateTime updatedAt;
+
+    // 생성자 ID
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    // 최종 수정자 ID
+    @LastModifiedBy
+    private String updatedBy;
+
+    // 엔티티 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EntityStatus status = EntityStatus.ACTIVE;
+
+    // JPA 사전 영속화 콜백
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // JPA 업데이트 콜백
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 상태 변경 메서드들
+    public void activate() {
+        this.status = EntityStatus.ACTIVE;
+    }
+
+    public void inactivate() {
+        this.status = EntityStatus.INACTIVE;
+    }
+
+    public void markDeleted() {
+        this.status = EntityStatus.DELETED;
+    }
+
+    // 현재 상태 확인 메서드
+    public boolean isActive() {
+        return this.status == EntityStatus.ACTIVE;
+    }
+
+    public boolean isInactive() {
+        return this.status == EntityStatus.INACTIVE;
+    }
+
+    public boolean isDeleted() {
+        return this.status == EntityStatus.DELETED;
+    }
+
+}

--- a/src/main/java/com/PickOne/common/entity/EntityStatus.java
+++ b/src/main/java/com/PickOne/common/entity/EntityStatus.java
@@ -1,0 +1,9 @@
+package com.PickOne.common.entity;
+
+public enum EntityStatus {
+
+    ACTIVE,      // 정상 상태
+    INACTIVE,    // 비활성화
+    DELETED      // 논리적 삭제
+
+}


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

- 공통 시스템 칼럼을 위한 BaseEntity 추상 클래스 구현
- 엔티티 생명주기 추적을 위한 EntityStatus 열거형 추가
- 감사 필드(생성일시, 수정일시) 포함
- 상태 관리 메서드 구현 (활성화, 비활성화, 삭제 표시)
- JPA 감사(Auditing) 설정 추가

## #️⃣연관된 이슈

> #1

## 💡 리뷰어에게 하고 싶은 말
- 엔티티 생성시 해당 엔티티 상속하면 시스템 칼럼 따로 작성할 필요없음

<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
